### PR TITLE
 Add public API to read and write HDF5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /.classpath
 /.project
 /.settings/
+
+# IDEA #
+/.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-		http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>17.1.1</version>
+		<version>22.0.2</version>
 		<relativePath />
 	</parent>
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>HDF5_Vibez</artifactId>
-	<version>0.2.0-SNAPSHOT</version>
+	<version>1.0.2-SNAPSHOT</version>
 
 	<name>HDF5 Vibez</name>
 	<description>HDF5 plugin for ImageJ and Fiji.</description>
@@ -68,8 +65,8 @@
 
 	<mailingLists>
 		<mailingList>
-			<name>ImageJ Forum</name>
-			<archive>http://forum.imagej.net/</archive>
+			<name>Image.sc Forum</name>
+			<archive>https://forum.image.sc/</archive>
 		</mailingList>
 	</mailingLists>
 
@@ -111,7 +108,6 @@
 		<dependency>
 			<groupId>cisd</groupId>
 			<artifactId>jhdf5</artifactId>
-			<version>14.12.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
 	<groupId>sc.fiji</groupId>
 	<artifactId>HDF5_Vibez</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
+	<version>0.2.0-SNAPSHOT</version>
 
 	<name>HDF5 Vibez</name>
 	<description>HDF5 plugin for ImageJ and Fiji.</description>

--- a/src/main/java/sc/fiji/hdf5/DataSetInfo.java
+++ b/src/main/java/sc/fiji/hdf5/DataSetInfo.java
@@ -1,0 +1,65 @@
+package sc.fiji.hdf5;
+
+import ij.IJ;
+
+import java.util.Comparator;
+
+class DataSetInfo
+{
+    static class DataSetInfoComparator implements Comparator<DataSetInfo> {
+        public int compare(DataSetInfo a, DataSetInfo b) {
+            return a.numericSortablePath.compareTo( b.numericSortablePath);
+        }
+    }
+
+    public String path;
+    public String numericSortablePath;
+    public String dimText;
+    public String typeText;
+    public String element_size_um_text;
+    final int numPaddingSize = 10;
+
+    public DataSetInfo( String p, String d, String t, String e) {
+        setPath(p);
+        dimText = d;
+        typeText = t;
+        element_size_um_text = e;
+    }
+
+    public void setPath( String p) {
+        path = p;
+        numericSortablePath = "";
+        String num = "";
+        for( int i = 0; i < p.length(); ++i) {
+            if (isNum(p.charAt(i))) {
+                num += p.charAt(i);
+            } else {
+                if (num != "") {
+                    for (int j = 0; j < numPaddingSize - num.length(); ++j) {
+                        numericSortablePath += "0";
+                    }
+                    numericSortablePath += num;
+                    num = "";
+                }
+                numericSortablePath += p.charAt(i);
+            }
+        }
+        if (num != "") {
+            for (int j = 0; j < numPaddingSize - num.length(); ++j) {
+                numericSortablePath += "0";
+            }
+            numericSortablePath += num;
+        }
+        IJ.log( path);
+        IJ.log( numericSortablePath);
+    }
+
+    public static Comparator<DataSetInfo> createComparator()
+    {
+        return new DataSetInfoComparator();
+    }
+
+    private boolean isNum( char c) {
+        return c >= '0' && c <= '9';
+    }
+}

--- a/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
@@ -69,26 +69,31 @@ public class HDF5ImageJ
     saveHyperStack( IJ.getImage(), filename, datasetname, "", "", 0, "replace");
   }
 
-  public static void hdf5write( String filename, String datasetname, boolean replace)
+  public static void hdf5write( ImagePlus imp, String filename, String datasetname)
+  {
+    saveHyperStack( imp, filename, datasetname, "", "", 0, "replace");
+  }
+
+  public static void hdf5write( ImagePlus imp, String filename, String datasetname, boolean replace)
   {
     if (replace) {
-      saveHyperStack(IJ.getImage(), filename, datasetname, "", "", 0, "replace");
+      saveHyperStack( imp, filename, datasetname, "", "", 0, "replace");
     } else {
-      saveHyperStack( IJ.getImage(), filename, datasetname, "", "", 0, "append");
+      saveHyperStack( imp, filename, datasetname, "", "", 0, "append");
     }
   }
 
-  public static void hdf5write( String filename, String datasetname, String formatTime, String formatChannel, int compressionLevel)
+  public static void hdf5write( ImagePlus imp, String filename, String datasetname, String formatTime, String formatChannel, int compressionLevel)
   {
-    saveHyperStack( IJ.getImage(), filename, datasetname, formatTime, formatChannel, compressionLevel, "replace");
+    saveHyperStack( imp, filename, datasetname, formatTime, formatChannel, compressionLevel, "replace");
   }
 
-  public static void hdf5write( String filename, String datasetname, String formatTime, String formatChannel, int compressionLevel, boolean replace)
+  public static void hdf5write( ImagePlus imp, String filename, String datasetname, String formatTime, String formatChannel, int compressionLevel, boolean replace)
   {
     if (replace) {
-      saveHyperStack(IJ.getImage(), filename, datasetname, formatTime, formatChannel, compressionLevel, "replace");
+      saveHyperStack( imp, filename, datasetname, formatTime, formatChannel, compressionLevel, "replace");
     } else {
-      saveHyperStack(IJ.getImage(), filename, datasetname, formatTime, formatChannel, compressionLevel, "append");
+      saveHyperStack( imp, filename, datasetname, formatTime, formatChannel, compressionLevel, "append");
     }
   }
 

--- a/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
@@ -108,6 +108,7 @@ public class HDF5ImageJ
   static ArrayList<DataSetInfo> recursiveGetInfo(IHDF5Reader reader, HDF5LinkInformation link)
   {
     ArrayList<DataSetInfo> dataSets = new ArrayList<DataSetInfo>();
+    recursiveGetInfo(reader, link, dataSets);
     return dataSets;
   }
 

--- a/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
@@ -118,9 +118,18 @@ public class HDF5ImageJ
 
     for (HDF5LinkInformation info : members)
     {
-      IJ.log(info.getPath() + ":" + info.getType());
-      switch (info.getType())
+      HDF5ObjectType type = info.getType();
+      IJ.log(info.getPath() + ":" + type);
+      switch (type)
       {
+        case EXTERNAL_LINK:
+          // update type to external link type - proceed through switch (no break)
+          // external link target paths are formatted: "EXTERNAL::/path/to/file::/path/to/object"
+          String[] extl_paths = info.tryGetSymbolicLinkTarget().split("::");
+          IHDF5Reader extl_reader = HDF5Factory.openForReading(extl_paths[1]);
+          HDF5LinkInformation extl_target = extl_reader.object().getLinkInformation(extl_paths[2]);
+          type = extl_target.getType();
+          extl_reader.close();
         case DATASET:
           HDF5DataSetInformation dsInfo = reader.object().getDataSetInformation(info.getPath());
           HDF5DataTypeInformation dsType = dsInfo.getTypeInformation();

--- a/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
@@ -168,7 +168,7 @@ public class HDF5ImageJ
 
           break;
         case GROUP:
-          recursiveGetInfo( reader, info);
+          recursiveGetInfo( reader, info, dataSets);
           //        node.add( browse(reader,info));
 
           break;

--- a/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5ImageJ.java
@@ -39,7 +39,6 @@ import ch.systemsx.cisd.base.mdarray.MDFloatArray;
 import ncsa.hdf.hdf5lib.exceptions.HDF5Exception;
 import java.awt.HeadlessException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class HDF5ImageJ
@@ -54,14 +53,14 @@ public class HDF5ImageJ
 
   public static ImagePlus hdf5read( String filename, String[] datasets, int nFrames, int nChannels)
   {
-    return loadDataSetsToHyperStack( filename, datasets, nFrames, nChannels);
+    return loadDataSetsToHyperStack( filename, datasets, nFrames, nChannels, false);
   }
 
   public static ImagePlus hdf5read( String filename, String datasetname, String layout)
   {
     String[] dsetNames = new String[1];
     dsetNames[0] = datasetname;
-    return loadCustomLayoutDataSetToHyperStack( filename, datasetname, layout);
+    return loadCustomLayoutDataSetToHyperStack( filename, datasetname, layout, false);
   }
 
   public static void hdf5write( String filename, String datasetname)
@@ -179,9 +178,15 @@ public class HDF5ImageJ
     }
   }
 
+  static ImagePlus loadDataSetsToHyperStack( String filename, String[] dsetNames,
+                                             int nFrames, int nChannels)
+  {
+    return loadDataSetsToHyperStack( filename, dsetNames, nFrames, nChannels, true);
+  }
+
   //-----------------------------------------------------------------------------
    static ImagePlus loadDataSetsToHyperStack( String filename, String[] dsetNames,
-                                            int nFrames, int nChannels)
+                                            int nFrames, int nChannels, boolean show)
   {
     String dsetName = "";
     try
@@ -346,10 +351,13 @@ public class HDF5ImageJ
       }
 
       imp.setC(1);
-      try {
-        imp.show();
+
+      if (show) {
+        try {
+          imp.show();
+        }
+        catch (HeadlessException herr) {}
       }
-      catch (HeadlessException herr) {}
       return imp;
     }
 
@@ -373,11 +381,15 @@ public class HDF5ImageJ
 
   }
 
+  static ImagePlus loadCustomLayoutDataSetToHyperStack( String filename, String dsetName, String layout) {
+    return loadCustomLayoutDataSetToHyperStack(filename, dsetName, layout, true);
+  }
+
   //-----------------------------------------------------------------------------
   //
   // Layout: any order of the letters x,y,z,c,t as string, e.g. "zyx" for a standard volumetric data set
   //
-  static ImagePlus loadCustomLayoutDataSetToHyperStack( String filename, String dsetName, String layout) {
+  static ImagePlus loadCustomLayoutDataSetToHyperStack( String filename, String dsetName, String layout, boolean show) {
     try
     {
       IHDF5ReaderConfigurator conf = HDF5Factory.configureForReading(filename);
@@ -666,10 +678,12 @@ public class HDF5ImageJ
 
       // aqdjust max gray
       imp.setDisplayRange(0,maxGray);
-      try {
-        imp.show();
+      if (show) {
+        try {
+          imp.show();
+        }
+        catch (HeadlessException herr) {}
       }
-      catch (HeadlessException herr) {}
       return imp;
     }
 

--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -27,54 +27,25 @@
 
 package sc.fiji.hdf5;
 
-import ij.CompositeImage;
 import ij.IJ;
-import ij.ImagePlus;
-import ij.ImageStack;
 import ij.Prefs;
-import ij.gui.GenericDialog;
 import ij.io.OpenDialog;
 import ij.plugin.PlugIn;
-import ij.process.ColorProcessor;
-import ij.process.ImageProcessor;
-import ij.process.ShortProcessor;
-import ij.process.ImageStatistics;
-import ij.process.StackStatistics;
-import ij.measure.Measurements;
 
 import java.io.File;
-import java.util.Date;
-import java.util.List;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Vector;
 
 import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.ActionEvent;
 import javax.swing.*;
-import javax.swing.tree.*;
 import javax.swing.JTable;
-import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableModel;
-import javax.swing.JCheckBox;
-
-
-import ch.systemsx.cisd.hdf5.HDF5DataSetInformation;
-import ch.systemsx.cisd.hdf5.HDF5DataTypeInformation;
-
 import ch.systemsx.cisd.hdf5.HDF5Factory;
 import ch.systemsx.cisd.hdf5.HDF5LinkInformation;
 import ch.systemsx.cisd.hdf5.IHDF5Reader;
-import ch.systemsx.cisd.hdf5.IHDF5Writer;
-import ch.systemsx.cisd.hdf5.IHDF5ReaderConfigurator;
-import ch.systemsx.cisd.base.mdarray.MDByteArray;
-import ch.systemsx.cisd.base.mdarray.MDFloatArray;
-import ch.systemsx.cisd.base.mdarray.MDShortArray;
-import ncsa.hdf.hdf5lib.exceptions.HDF5Exception; 
-
 
 
 public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener 


### PR DESCRIPTION
* DataSetInfo os now in its own namespace.
* HDF5ImageJ now has `hdf5list` method to list contents of HDF5 file
* `hdf5read` and `hdf5write` methods are now more flexible (writers take ImagePlus as argument)
* HDF5_Reader_Vibez now uses abstracted DataSetInfo class
* Proposed version bump to 0.2.0 (as new features were added)