### PR TITLE
Add support for external links

### DIFF
--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -475,6 +475,48 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
         //        node.add( browse(reader,info));
         
         break;
+
+      // Procedure for DATASET seems to work for EXTERNAL_LINK just fine!
+      case EXTERNAL_LINK:
+        dsInfo = reader.object().getDataSetInformation(info.getPath());
+        dsType = dsInfo.getTypeInformation();
+
+        IJ.log(info.getPath() + ":" + dsInfo);
+        
+        dimText = "";
+        if( dsInfo.getRank() == 0) 
+        {
+          dimText ="1";
+        }
+        else
+        {
+          dimText += dsInfo.getDimensions()[0];
+          for( int i = 1; i < dsInfo.getRank(); ++i)
+          {
+            dimText += "x" + dsInfo.getDimensions()[i];
+          }
+        }
+        
+
+        typeText = HDF5ImageJ.dsInfoToTypeString(dsInfo);
+          
+        // try to read element_size_um attribute
+        element_size_um_text = "unknown";
+        try {
+          float[] element_size_um = reader.float32().getArrayAttr(info.getPath(), "element_size_um");
+          element_size_um_text = "" + element_size_um[0] + "x" 
+              + element_size_um[1] + "x" + element_size_um[2];
+          
+        }     
+        catch (HDF5Exception err) {
+          IJ.log("Warning: Can't read attribute 'element_size_um' from dataset '" + info.getPath() + "':\n"
+                 + err );
+        }
+
+        dataSets_.add( new DataSetInfo( info.getPath(), dimText, typeText, 
+                                        element_size_um_text));
+
+        break;
       default:
         break;
       }

--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -87,13 +87,15 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
     public String dimText;
     public String typeText;
     public String element_size_um_text;
+    public String region_reference;
     final int numPaddingSize = 10;
-    
-    public DataSetInfo( String p, String d, String t, String e) {
+
+    public DataSetInfo( String p, String d, String t, String e, String r) {
       setPath(p);
       dimText = d;
       typeText = t; 
       element_size_um_text = e;
+      region_reference = r;
     }
 
     public void setPath( String p) {
@@ -470,11 +472,20 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
                  + err );
         } 
 
+        String region_reference = "unset";
+        try {
+          String regref_name = (info.getPath() + "_CONTAINER_SLICE_REGION").substring(1);
+          region_reference = reader.reference().getAttr("/", regref_name, false);
+        }
+        catch (HDF5Exception err) {
+          IJ.log("Warning: No Region Reference for:\n" + err);
+        }
+
         IJ.log(info.getPath() + ":" + dsInfo);
 
         dataSets_.add( new DataSetInfo( info.getPath(), dimText, typeText, 
-                                        element_size_um_text));
-        
+                                        element_size_um_text,
+                                        region_reference));
         
         break;
       case SOFT_LINK:

--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -434,6 +434,7 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
         IHDF5Reader extl_reader = HDF5Factory.openForReading(extl_paths[1]);
         HDF5LinkInformation extl_target = extl_reader.object().getLinkInformation(extl_paths[2]);
         type = extl_target.getType();
+        extl_reader.close();
 
       case DATASET:
         HDF5DataSetInformation dsInfo = reader.object().getDataSetInformation(info.getPath());

--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -87,15 +87,13 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
     public String dimText;
     public String typeText;
     public String element_size_um_text;
-    public String region_reference;
     final int numPaddingSize = 10;
 
-    public DataSetInfo( String p, String d, String t, String e, String r) {
+    public DataSetInfo( String p, String d, String t, String e) {
       setPath(p);
       dimText = d;
       typeText = t; 
       element_size_um_text = e;
-      region_reference = r;
     }
 
     public void setPath( String p) {
@@ -470,22 +468,12 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
         catch (HDF5Exception err) {
           IJ.log("Warning: Can't read attribute 'element_size_um' from dataset '" + info.getPath() + "':\n"
                  + err );
-        } 
-
-        String region_reference = "unset";
-        try {
-          String regref_name = (info.getPath() + "_CONTAINER_SLICE_REGION").substring(1);
-          region_reference = reader.reference().getAttr("/", regref_name, false);
-        }
-        catch (HDF5Exception err) {
-          IJ.log("Warning: No Region Reference for:\n" + err);
         }
 
         IJ.log(info.getPath() + ":" + dsInfo);
 
         dataSets_.add( new DataSetInfo( info.getPath(), dimText, typeText, 
-                                        element_size_um_text,
-                                        region_reference));
+                                        element_size_um_text));
         
         break;
       case SOFT_LINK:


### PR DESCRIPTION
The switch statement in the HDF5_Reader_Vibez.java recursiveGetInfo() function now checks for the EXTERNAL_LINK type first. The object type is updated to the external link type and the switch statement simply proceeds as normal. I've tested these changes against a container file with external links to datasets in other files, it works fine and will be a big help to me!