### PR TITLE
check if plugin called with valid file path string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /.classpath
 /.project
 /.settings/
+
+# OS X #
+.DS_Store

--- a/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
+++ b/src/main/java/sc/fiji/hdf5/HDF5_Reader_Vibez.java
@@ -156,31 +156,38 @@ public class HDF5_Reader_Vibez extends JFrame  implements PlugIn, ActionListener
     String name = "";
     boolean tryAgain;
     String openMSG = "Open HDF5...";
-    do {
-      tryAgain = false;
-      OpenDialog od;
-      if (directory.equals(""))
-          od = new OpenDialog(openMSG, "");
-      else
-          od = new OpenDialog(openMSG, directory, "");
-      
-      directory = od.getDirectory();
-      name = od.getFileName();
-      if (name == null)
-          return;
-      if (name == "")
-          return;
-      
-      File testFile = new File(directory + name);
-      if (!testFile.exists() || !testFile.canRead())
-          return;
-      
-      if (testFile.isDirectory()) {
-        directory = directory + name;
-        tryAgain = true;
-      }
-    } while (tryAgain);
-    
+
+    if (arg != null && arg.endsWith("hdf")){
+      File theFile = new File(arg);
+      directory = theFile.getParent();
+      if (!directory.endsWith("/")) directory += "/"; 
+      name = theFile.getName();
+    } else {
+        do {
+          tryAgain = false;
+          OpenDialog od;
+          if (directory.equals(""))
+              od = new OpenDialog(openMSG, "");
+          else
+              od = new OpenDialog(openMSG, directory, "");
+          
+          directory = od.getDirectory();
+          name = od.getFileName();
+          if (name == null)
+              return;
+          if (name == "")
+              return;
+          
+          File testFile = new File(directory + name);
+          if (!testFile.exists() || !testFile.canRead())
+              return;
+          
+          if (testFile.isDirectory()) {
+            directory = directory + name;
+            tryAgain = true;
+          }
+        } while (tryAgain);
+  }
 
     // Get All Dataset names
     //


### PR DESCRIPTION
Before opening a file selection dialog window, checks if plugin has been called with a valid file path string. This is very useful if you want to enable drag-and-drop file opening by setting relevant file types to open with HDF5_Reader_Vibez in HandleExtraFileTypes.java within FIJI's IO package.